### PR TITLE
Parameterized name as suffix for all resources tag

### DIFF
--- a/blueprints/01-getting-started/.auto.tfvars.example
+++ b/blueprints/01-getting-started/.auto.tfvars.example
@@ -1,3 +1,5 @@
+# name = "random-id" # Optional, enter unique name / random id here
+region = "us-east-1" # Required, change this according to your target region
 domain_name = "example.domain.com" # Required. Domain name used by the CloudBees CI instance.
 
 temp_license = { # Required. Temporary license details.
@@ -12,3 +14,6 @@ temp_license = { # Required. Temporary license details.
 #   "cb-user" : "crodriguezlopez"
 #   "cb-environment" : "demo"
 # }
+
+# k8s_version = "1.27" Optional
+# vpc_cidr = "10.0.0.0/16" Optional

--- a/blueprints/01-getting-started/main.tf
+++ b/blueprints/01-getting-started/main.tf
@@ -5,18 +5,18 @@ data "aws_route53_zone" "this" {
 data "aws_availability_zones" "available" {}
 
 locals {
-  name   = "cbci-bp01-i${random_integer.ramdom_id.result}"
-  region = "us-east-1"
+  name   = "cbci-bp-${var.name}"
+  region = var.region
 
   vpc_name             = "${local.name}-vpc"
   cluster_name         = "${local.name}-eks"
   kubeconfig_file      = "kubeconfig_${local.name}.yaml"
   kubeconfig_file_path = abspath("${path.root}/${local.kubeconfig_file}")
 
-  vpc_cidr = "10.0.0.0/16"
+  vpc_cidr = var.vpc_cidr
 
   #https://docs.cloudbees.com/docs/cloudbees-common/latest/supported-platforms/cloudbees-ci-cloud#_kubernetes
-  k8s_version = "1.26"
+  k8s_version = var.k8s_version
 
   route53_zone_id  = data.aws_route53_zone.this.id
   route53_zone_arn = data.aws_route53_zone.this.arn
@@ -29,11 +29,6 @@ locals {
     "tf:blueprint"  = local.name
     "tf:repository" = "github.com/cloudbees/terraform-aws-cloudbees-ci-eks-addon"
   })
-}
-
-resource "random_integer" "ramdom_id" {
-  min = 1
-  max = 999
 }
 
 ################################################################################

--- a/blueprints/01-getting-started/variables.tf
+++ b/blueprints/01-getting-started/variables.tf
@@ -1,3 +1,17 @@
+variable "name" {
+  description = "Unique name to be assigned to all resources"
+  default     = ""
+  type        = string
+}
+
+variable "region" {
+  description = "The region from which this module will be executed."
+  type        = string
+  validation {
+    condition     = can(regex("(us(-gov)?|ap|ca|cn|eu|sa)-(central|(north|south)?(east|west)?)-\\d", var.region))
+    error_message = "Variable var: region is not valid."
+  }
+}
 
 variable "tags" {
   description = "Tags to apply to resources"
@@ -17,4 +31,20 @@ variable "domain_name" {
 variable "temp_license" {
   description = "Temporary license details"
   type        = map(string)
+}
+
+variable "k8s_version" {
+  description = "EKS cluster version, refer to: https://docs.cloudbees.com/docs/cloudbees-common/latest/supported-platforms/cloudbees-ci-cloud#_kubernetes "
+  type        = string
+  default     = "1.26"
+}
+
+variable "vpc_cidr" {
+  description = "CIDR for the EKS cluster VPC"
+  type = string
+  default = "10.0.0.0/16"
+  validation {
+    condition     = can(cidrhost(var.vpc_cidr, 0))
+    error_message = "Must be valid IPv4 CIDR."
+  }
 }

--- a/blueprints/01-getting-started/variables.tf
+++ b/blueprints/01-getting-started/variables.tf
@@ -41,8 +41,8 @@ variable "k8s_version" {
 
 variable "vpc_cidr" {
   description = "CIDR for the EKS cluster VPC"
-  type = string
-  default = "10.0.0.0/16"
+  type        = string
+  default     = "10.0.0.0/16"
   validation {
     condition     = can(cidrhost(var.vpc_cidr, 0))
     error_message = "Must be valid IPv4 CIDR."


### PR DESCRIPTION
Resolve #29 

Since `for_each` cannot resolve value from random-id provider, the best way to address this is by letting customer to choose the random id. This will keep it deterministic for each plan / apply.

I also externalized other parameters such as EKS version and CIDR. This allows end-user to use the module as-is from abstraction such as AWS Service Catalog or Terraform Cloud no-code provisioning without making changes to the locals.